### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 
 Don't settle for boring buttons. Impress your users instead with this beautiful Bootstrap button pack.
 
-###Demo
+### Demo
 [Check out the demo here](http://bootstrapbay.com/demo/push/demo)
 
-###Code
+### Code
 - Compatible with Bootstrap 3.2
 - Neatly organized CSS code for easy implementation
 
-###Button Styles
+### Button Styles
 - Standard
 - Sharp
 - Outline


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
